### PR TITLE
pmd/7.0.x-kotlin/hasImport

### DIFF
--- a/docs/_data/xpath_funs.yml
+++ b/docs/_data/xpath_funs.yml
@@ -199,29 +199,5 @@ langs:
         examples:
           - code: '/KotlinFile[pmd-kotlin:hasImport('javax.xml.xpath')]'
             outcome: "true or false"
-
-      - name: hasImport
-        returnType: "xs:boolean"
-        shortDescription: "Test for an import header"
-        description: "Returns true if the document has the specified package in the import header"
-        parameters:
-          - name: "package"
-            type: "xs:string"
-            description: "The fully qualified package name"
-        examples:
-          - code: '/KotlinFile[pmd-kotlin:hasImport('javax.xml.xpath')]'
-            outcome: "true or false"
-
-      - name: hasImport
-        returnType: "xs:boolean"
-        shortDescription: "Test for an import header"
-        description: "Returns true if the document has the specified package in the import header"
-        parameters:
-          - name: "package"
-            type: "xs:string"
-            description: "The fully qualified package name"
-        examples:
-          - code: '/KotlinFile[pmd-kotlin:hasImport('javax.xml.xpath')]'
-            outcome: "true or false"
           - code: '//FunctionBody//T-Identifier[@Text='newXPath' and pmd-kotlin:hasImport('javax.xml.xpath')]'
             outcome: "true or false"

--- a/docs/_data/xpath_funs.yml
+++ b/docs/_data/xpath_funs.yml
@@ -187,3 +187,41 @@ langs:
         examples:
           - code: '//Identifier[pmd-kotlin:hasChildren(3)]'
             outcome: "true or false"
+
+      - name: hasImport
+        returnType: "xs:boolean"
+        shortDescription: "Test for an import header"
+        description: "Returns true if the document has the specified package in the import header"
+        parameters:
+          - name: "package"
+            type: "xs:string"
+            description: "The fully qualified package name"
+        examples:
+          - code: '/KotlinFile[pmd-kotlin:hasImport('javax.xml.xpath')]'
+            outcome: "true or false"
+
+      - name: hasImport
+        returnType: "xs:boolean"
+        shortDescription: "Test for an import header"
+        description: "Returns true if the document has the specified package in the import header"
+        parameters:
+          - name: "package"
+            type: "xs:string"
+            description: "The fully qualified package name"
+        examples:
+          - code: '/KotlinFile[pmd-kotlin:hasImport('javax.xml.xpath')]'
+            outcome: "true or false"
+
+      - name: hasImport
+        returnType: "xs:boolean"
+        shortDescription: "Test for an import header"
+        description: "Returns true if the document has the specified package in the import header"
+        parameters:
+          - name: "package"
+            type: "xs:string"
+            description: "The fully qualified package name"
+        examples:
+          - code: '/KotlinFile[pmd-kotlin:hasImport('javax.xml.xpath')]'
+            outcome: "true or false"
+          - code: '//FunctionBody//T-Identifier[@Text='newXPath' and pmd-kotlin:hasImport('javax.xml.xpath')]'
+            outcome: "true or false"

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/KotlinHandler.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/KotlinHandler.java
@@ -17,7 +17,8 @@ public class KotlinHandler extends AbstractPmdLanguageVersionHandler {
 
     private static final XPathHandler XPATH_HANDLER =
         XPathHandler.getHandlerForFunctionDefs(
-            BaseContextNodeTestFun.HAS_CHILDREN
+            BaseContextNodeTestFun.HAS_CHILDREN,
+            BaseContextNodeTestFun.HAS_IMPORT
         );
 
     public KotlinHandler(String release) {

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/xpath/internal/BaseContextNodeTestFun.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/xpath/internal/BaseContextNodeTestFun.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.kotlin.rule.xpath.internal;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinNode;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser;
 import net.sourceforge.pmd.lang.rule.xpath.internal.AstElementNode;
 
 import net.sf.saxon.expr.XPathContext;
@@ -14,6 +15,11 @@ import net.sf.saxon.om.Sequence;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.value.BooleanValue;
 import net.sf.saxon.value.SequenceType;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiPredicate;
 
 /**
  * XPath function {@code pmd-kotlin:hasChildren(count as xs:decimal) as xs:boolean}
@@ -26,12 +32,15 @@ public class BaseContextNodeTestFun<T extends KotlinNode> extends BaseKotlinXPat
 
     static final SequenceType[] NO_ARGUMENTS = { SequenceType.SINGLE_INTEGER };
     private final Class<T> klass;
+    private final BiPredicate<String, T> checker;
 
-    public static final BaseKotlinXPathFunction HAS_CHILDREN = new BaseContextNodeTestFun<>(KotlinNode.class, "hasChildren");
+    public static final BaseKotlinXPathFunction HAS_CHILDREN = new BaseContextNodeTestFun<>(KotlinNode.class, "hasChildren", TestUtil::hasChildren);
+    public static final BaseKotlinXPathFunction HAS_IMPORT = new BaseContextNodeTestFun<>(KotlinNode.class, "hasImport", TestUtil::hasImport);
 
-    protected BaseContextNodeTestFun(Class<T> klass, String localName) {
+    protected BaseContextNodeTestFun(Class<T> klass, String localName, BiPredicate<String, T> checker) {
         super(localName);
         this.klass = klass;
+        this.checker = checker;
     }
 
     @Override
@@ -55,10 +64,87 @@ public class BaseContextNodeTestFun<T extends KotlinNode> extends BaseKotlinXPat
             @Override
             public Sequence call(XPathContext context, Sequence[] arguments) throws XPathException {
                 Node contextNode = ((AstElementNode) context.getContextItem()).getUnderlyingNode();
-                boolean hasChildren = contextNode.getNumChildren() == Integer.parseInt(arguments[0].head().getStringValue());
-                return BooleanValue.get(klass.isInstance(contextNode) && hasChildren);
+                return BooleanValue.get(klass.isInstance(contextNode) && checker.test(arguments[0].head().getStringValue(), (T) contextNode));
             }
         };
     }
+
+}
+
+class TestUtil {
+    private TestUtil() {
+        // utility class
+    }
+
+    public static boolean hasImport(final @NonNull String reqPackage, final @NonNull Node node) {
+        // assuming root is /KotlinFile, if not, add getFirstChild()
+        boolean aHeaderHasImport = false;
+        Node root = node.getRoot();
+        int numChildren = root.getNumChildren();
+        for (int i = 0; i < numChildren; i++) {
+            if (root.getChild(i) instanceof KotlinParser.KtImportList) {
+                aHeaderHasImport = headerHasImport(reqPackage, (KotlinParser.KtImportList)node);
+            }
+        }
+        return aHeaderHasImport;
+    }
+
+    private static boolean headerHasImport(final @NonNull String reqPackage, final KotlinParser.KtImportList node) {
+        int numChildren = node.getNumChildren();
+        for (int i = 0; i < numChildren; i++) {
+            if (node.getChild(i) instanceof KotlinParser.KtImportHeader) {
+                List<KotlinParser.KtSimpleIdentifier> simpleIdentifiers = ((KotlinParser.KtImportHeader) node.getChild(i)).identifier().simpleIdentifier(); // multiple
+                List<String> importParts = new ArrayList<>();
+                for (KotlinParser.KtSimpleIdentifier smplIdentifier: simpleIdentifiers) {
+                    importParts.add(smplIdentifier.Identifier().getText()); // In designer called T-Identifier
+                }
+                String importJoined = String.join(".", importParts);
+                if (importJoined.contains(reqPackage)) return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean hasChildren(final @NonNull String reqNumChildren, final @NonNull Node node) {
+        return node.getNumChildren() == Integer.parseInt(reqNumChildren);
+    }
+
+    /**
+     * Checks whether the static type of the node is a subtype of the
+     * class identified by the given name. This ignores type arguments,
+     * if the type of the node is parameterized. Examples:
+     *
+     * <pre>{@code
+     * isA(List.class, <new ArrayList<String>()>)      = true
+     * isA(ArrayList.class, <new ArrayList<String>()>) = true
+     * isA(int[].class, <new int[0]>)                  = true
+     * isA(Object[].class, <new String[0]>)            = true
+     * isA(_, null) = false
+     * isA(null, _) = NullPointerException
+     * }</pre>
+     *
+     * <p>If either type is unresolved, the types are tested for equality,
+     * thus giving more useful results than {@link JTypeMirror#isSubtypeOf(JTypeMirror)}.
+     *
+     * <p>Note that primitives are NOT considered subtypes of one another
+     * by this method, even though {@link JTypeMirror#isSubtypeOf(JTypeMirror)} does.
+     *
+     * @param clazz a class (non-null)
+     * @param node  the type node to check
+     *
+     * @return true if the type test matches
+     *
+     * @throws NullPointerException if the class parameter is null
+     * TODO
+     */
+    /*public static boolean isA(final @NonNull Class<?> clazz, final @Nullable TypeNode node) {
+        AssertionUtil.requireParamNotNull("class", clazz);
+        if (node == null) {
+            return false;
+        }
+
+        return hasNoSubtypes(clazz) ? isExactlyA(clazz, node)
+                : isA(clazz, node.getTypeMirror());
+    }*/
 
 }

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/xpath/internal/BaseContextNodeTestFun.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/xpath/internal/BaseContextNodeTestFun.java
@@ -25,7 +25,8 @@ import java.util.List;
 import java.util.function.BiPredicate;
 
 /**
- * XPath function {@code pmd-kotlin:hasChildren(count as xs:decimal) as xs:boolean}
+ * XPath function {@code pmd-kotlin:hasChildren(count as xs:decimal) as xs:boolean} and
+ * {@code pmd-kotlin:hasImport(package as xs:string) as xs:boolean}
  *
  * <p>Example XPath 3.1: {@code //Identifier[pmd-kotlin:hasChildren(3)]}
  *
@@ -37,8 +38,8 @@ public class BaseContextNodeTestFun<T extends KotlinNode> extends BaseKotlinXPat
     private final Class<T> klass;
     private final BiPredicate<String, T> checker;
 
-    public static final BaseKotlinXPathFunction HAS_CHILDREN = new BaseContextNodeTestFun<>(KotlinNode.class, "hasChildren", TestUtil::hasChildren);
-    public static final BaseKotlinXPathFunction HAS_IMPORT = new BaseContextNodeTestFun<>(KotlinNode.class, "hasImport", TestUtil::hasImport);
+    public static final BaseKotlinXPathFunction HAS_CHILDREN = new BaseContextNodeTestFun<>(KotlinNode.class, "hasChildren", TestFunUtil::hasChildren);
+    public static final BaseKotlinXPathFunction HAS_IMPORT = new BaseContextNodeTestFun<>(KotlinNode.class, "hasImport", TestFunUtil::hasImport);
 
     protected BaseContextNodeTestFun(Class<T> klass, String localName, BiPredicate<String, T> checker) {
         super(localName);
@@ -74,8 +75,8 @@ public class BaseContextNodeTestFun<T extends KotlinNode> extends BaseKotlinXPat
 
 }
 
-class TestUtil {
-    private TestUtil() {
+class TestFunUtil {
+    private TestFunUtil() {
         // utility class
     }
 


### PR DESCRIPTION
## Describe the PR
Introduction of the hasImport XPath function for Kotlin, to replace boilerplate XPath code we need because of missing typeIs function. 

Now corrected to a PR on pmd/7.0.x branch (not master)

## Related issues
 #4858
 #3808

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

